### PR TITLE
docs/index.md: Convert AB3 to Hall-y

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,17 @@
 ---
 layout: page
-title: AddressBook Level-3
+title: Hall-y
 ---
 
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
-[![codecov](https://codecov.io/gh/se-edu/addressbook-level3/branch/master/graph/badge.svg)](https://codecov.io/gh/se-edu/addressbook-level3)
+[![CI Status](https://github.com/AY2021S1-CS2103T-T11-2/tp/workflows/Java%20CI/badge.svg)](https://github.com/AY2021S1-CS2103T-T11-2/tp/actions)
+[![codecov](https://codecov.io/gh/AY2021S1-CS2103T-T11-2/tp/branch/master/graph/badge.svg)](https://codecov.io/gh/AY2021S1-CS2103T-T11-2/tp)
 
 ![Ui](images/Ui.png)
 
-**AddressBook is a desktop application for managing your contact details.** While it has a GUI, most of the user interactions happen using a CLI (Command Line Interface).
+**Hall-y is a desktop application for managing your hall residents.** While it has a GUI, most of the user interactions happen using a CLI (Command Line Interface).
 
-* If you are interested in using AddressBook, head over to the [_Quick Start_ section of the **User Guide**](UserGuide.html#quick-start).
-* If you are interested about developing AddressBook, the [**Developer Guide**](DeveloperGuide.html) is a good place to start.
+* If you are interested in using Hall-y, head over to the [_Quick Start_ section of the **User Guide**](UserGuide.html#quick-start).
+* If you are interested about developing Hall-y, the [**Developer Guide**](DeveloperGuide.html) is a good place to start.
 
 
 **Acknowledgements**


### PR DESCRIPTION
Convert AB3 to Hall-y in the `docs/index.md` file.

This will cause the project site to update accordingly - the site should now be mostly referring to Hall-y instead of AB3 (except images and other things).

As part of #53 as well.