### PR TITLE
Enable assertions in Gradle's run configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,10 @@ checkstyle {
     toolVersion = '8.29'
 }
 
+run {
+    enableAssertions = true
+}
+
 test {
     useJUnitPlatform()
     finalizedBy jacocoTestReport


### PR DESCRIPTION
Enable the assertions as required in the tP tracker.

When executing gradle's run method, assertions will be enabled now.